### PR TITLE
Fix small include mistake

### DIFF
--- a/cmake/EngineCode/CMakeLists.txt
+++ b/cmake/EngineCode/CMakeLists.txt
@@ -7,6 +7,7 @@ set( C4SourceFiles
     ${C4EngineCodeDir}/C4+Windows.rc
     ${C4EngineCodeDir}/C4+Wintab.cpp 
     ${C4EngineCodeDir}/C4Memory.cpp
+    ${C4EngineCodeDir}/C4Engine.cpp
     # Base > TerathonCode
     ${C4TerathonCodeDir}/TSTools.cpp
     #Controllers


### PR DESCRIPTION
Hi,

I noticed that when editing C4Engine.cpp i get the C4Engine_ref.cpp reason being it didnt get included so visual studio was smart enough to find it but it copied to the build folder made by cmake.

So anyways this fixes that.